### PR TITLE
Remove Async executors and replace with tokio as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-crazyflie-link = { version="0.2.2", default-features = false }
-async_executors = { version="0.4.2", features=["timer"] }
+crazyflie-link = { git = "https://github.com/bitcraze/crazyflie-link-rs.git", branch = "evoggy/tokio-as-feature" }
 futures-util = "0.3"
 futures = "0.3"
 async-stream = "0.3.1"
@@ -24,14 +23,14 @@ async-trait = "0.1.50"
 num_enum = "0.5.1"
 half = "1.7.1"
 async-broadcast = "0.3.4"
+tokio = { version = "1.36.0", features = ["full"], optional = true }
 
-async-std = { version = "1.9.0", features = ["attributes"], optional = true }
 wasm-bindgen-futures = { version = "0.4.24", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9.0"
-async_executors = { version="0.4.2", features=["async_std"] }
 
 [features]
-default = ["async-std", "crazyflie-link/native"]
+default = ["tokio", "crazyflie-link/native"]
+tokio = ["dep:tokio"]
 web = ["wasm-bindgen-futures", "crazyflie-link/webusb"]

--- a/examples/appchannel.rs
+++ b/examples/appchannel.rs
@@ -17,9 +17,9 @@ use futures::{SinkExt, StreamExt};
 //
 // Like most of the other examples, it scans for Crazyflies and connect the fist one
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+    let link_context = crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     println!("Scanning for Crazyflie.");
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if let Some(uri) = found.first() {
         println!("Connecting to {}", &uri);
-        let cf = Crazyflie::connect_from_uri(async_executors::AsyncStd, &link_context, uri).await?;
+        let cf = Crazyflie::connect_from_uri(&link_context, uri).await?;
 
         let (mut tx, mut rx) = cf.platform.get_app_channel().await.unwrap();
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 // Example scans for Crazyflies, connect the first one and print the log and param variables TOC.
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+    let link_context = crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     let found = link_context.scan([0xE7; 5]).await?;
@@ -10,7 +10,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Connecting to {} ...", uri);
 
         let cf = crazyflie_lib::Crazyflie::connect_from_uri(
-            async_executors::AsyncStd,
             &link_context,
             uri,
         )

--- a/examples/console.rs
+++ b/examples/console.rs
@@ -1,12 +1,10 @@
-use std::time::Duration;
-
-use async_std::future::timeout;
+use tokio::time::{Duration, timeout};
 use futures::StreamExt;
 
 // Example scans for Crazyflies, connect the first one and print the console message line by line.
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+    let link_context = crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     let found = link_context.scan([0xE7; 5]).await?;
@@ -15,7 +13,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Connecting to {} ...", uri);
 
         let cf = crazyflie_lib::Crazyflie::connect_from_uri(
-            async_executors::AsyncStd,
             &link_context,
             uri,
         )

--- a/examples/list_logs.rs
+++ b/examples/list_logs.rs
@@ -1,11 +1,11 @@
 const URI: &str = "radio://0/60/2M/E7E7E7E7E7";
 
 // Example that prints a list of the log variables
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+    let link_context = crazyflie_link::LinkContext::new();
     let cf =
-        crazyflie_lib::Crazyflie::connect_from_uri(async_executors::AsyncStd, &link_context, URI)
+        crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI)
             .await?;
 
     println!("{0: <30} | {1: <5}", "Name", "Type");

--- a/examples/list_params.rs
+++ b/examples/list_params.rs
@@ -1,11 +1,11 @@
 const URI: &str = "radio://0/60/2M/E7E7E7E7E7";
 
 // Example that prints a list of the param variables
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+    let link_context = crazyflie_link::LinkContext::new();
     let cf =
-        crazyflie_lib::Crazyflie::connect_from_uri(async_executors::AsyncStd, &link_context, URI)
+        crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI)
             .await?;
 
     println!("{: <30} | {: <6} | {: <6}", "Name", "Access", "Value");

--- a/examples/motor_ramp.rs
+++ b/examples/motor_ramp.rs
@@ -1,13 +1,12 @@
 /// Simple example that ramps the motor thrust and then stops them
 use crazyflie_lib::Crazyflie;
 use crazyflie_link::LinkContext;
-use std::time::Duration;
+use tokio::time::{Duration, sleep};
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let context = LinkContext::new(async_executors::AsyncStd);
+    let context = LinkContext::new();
     let crazyflie = Crazyflie::connect_from_uri(
-        async_executors::AsyncStd,
         &context,
         "radio://0/80/2M/E7E7E7E7E7",
     )
@@ -26,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .setpoint_rpyt(0.0, 0.0, 0.0, thrust)
             .await?;
 
-        async_std::task::sleep(runtime / (steps as u32)).await;
+        sleep(runtime / (steps as u32)).await;
     }
 
     Ok(())

--- a/examples/test_logs.rs
+++ b/examples/test_logs.rs
@@ -1,12 +1,12 @@
 use crazyflie_lib::{subsystems::log::LogPeriod, Crazyflie};
 use crazyflie_link::LinkContext;
-use std::{convert::TryInto, time::Duration};
+use std::convert::TryInto;
+use tokio::time::{Duration, sleep};
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let context = LinkContext::new(async_executors::AsyncStd);
+    let context = LinkContext::new();
     let cf = Crazyflie::connect_from_uri(
-        async_executors::AsyncStd,
         &context,
         "radio://0/80/2M/E7E7E7E7E7",
     )
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let block = stream.stop().await?;
 
     println!(" --- Pausing log for 3 seconds --- ");
-    async_std::task::sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(3)).await;
 
     let stream = block.start(LogPeriod::from_millis(10)?).await?;
 

--- a/examples/test_params.rs
+++ b/examples/test_params.rs
@@ -2,11 +2,10 @@ use crazyflie_lib::Crazyflie;
 use crazyflie_link::LinkContext;
 use futures::StreamExt;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let context = LinkContext::new(async_executors::AsyncStd);
+    let context = LinkContext::new();
     let crazyflie = Crazyflie::connect_from_uri(
-        async_executors::AsyncStd,
         &context,
         "radio://0/60/2M/E7E7E7E7E7",
     )
@@ -14,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Launch a task to watch param changes
     let mut param_watcher = crazyflie.param.watch_change().await;
-    async_std::task::spawn(async move {
+    tokio::spawn(async move {
         while let Some((name, value)) = param_watcher.next().await {
             println!(
                 " > Param watcher: '{}' updated with value {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,13 +45,13 @@
 //! For example:
 //! ``` no_run
 //! # async fn test() -> Result<(), Box<dyn std::error::Error>> {
-//! let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+//! let link_context = crazyflie_link::LinkContext::new();
 //!
 //! // Scan for Crazyflies on the default address
 //! let found = link_context.scan([0xE7; 5]).await?;
 //!
 //! if let Some(uri) = found.first() {
-//!     let cf = crazyflie_lib::Crazyflie::connect_from_uri(async_executors::AsyncStd, &link_context, uri).await?;
+//!     let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, uri).await?;
 //!
 //!     println!("List of params variables: ");
 //!     for name in cf.param.names() {
@@ -84,24 +84,12 @@ pub use crate::crazyflie::Crazyflie;
 pub use crate::error::{Error, Result};
 pub use crate::value::{Value, ValueType};
 
-// Async executor selection
-#[cfg(feature = "async-std")]
-pub(crate) use async_std::task::spawn;
-
 #[cfg(feature = "wasm-bindgen-futures")]
 use wasm_bindgen_futures::spawn_local as spawn;
 
-use async_executors::{LocalSpawnHandle, Timer};
-
-/// Async executor trait
-///
-/// This trait is implemented in the `async_executors` crate for common async
-/// executors. See example in the [crate root documentation](crate).
-pub trait Executor: LocalSpawnHandle<()> + Timer + 'static {}
-
-// Until trait alias makes it in stable rust, we need an empty implementation
-// for this trait ...
-impl<U> Executor for U where U: LocalSpawnHandle<()> + Timer + 'static {}
+// Check if the feature tokio is set
+#[cfg(not(feature = "tokio"))]
+compile_error!("feature \"tokio\" must be enabled at this time");
 
 /// Supported protocol version
 ///

--- a/src/subsystems/commander.rs
+++ b/src/subsystems/commander.rs
@@ -13,7 +13,7 @@
 //!
 //! The following example code would drive the motors in a ramp and then stop:
 //! ``` no_run
-//! # use std::time::Duration;
+//! # use tokio::time::{sleep, Duration};
 //! # async fn ramp(crazyflie: crazyflie_lib::Crazyflie) -> Result<(), Box<dyn std::error::Error>> {
 //! // Unlock the commander
 //! crazyflie.commander.setpoint_rpyt(0.0, 0.0, 0.0, 0).await?;
@@ -21,7 +21,7 @@
 //! // Ramp!
 //! for thrust in (0..20_000).step_by(1_000) {
 //!     crazyflie.commander.setpoint_rpyt(0.0, 0.0, 0.0, thrust).await?;
-//!     async_std::task::sleep(Duration::from_millis(100)).await;
+//!     sleep(Duration::from_millis(100)).await;
 //! }
 //!
 //! // Stop the motors

--- a/src/subsystems/log.rs
+++ b/src/subsystems/log.rs
@@ -10,8 +10,8 @@
 //! # use crazyflie_lib::{Crazyflie, Value, Error, subsystems::log::LogPeriod};
 //! # use crazyflie_link::LinkContext;
 //! # async fn example() -> Result<(), Error> {
-//! # let context = LinkContext::new(async_executors::AsyncStd);
-//! # let cf = Crazyflie::connect_from_uri(async_executors::AsyncStd, &context, "radio://0/60/2M/E7E7E7E7E7").await?;
+//! # let context = LinkContext::new();
+//! # let cf = Crazyflie::connect_from_uri(&context, "radio://0/60/2M/E7E7E7E7E7").await?;
 //! // Create the log block
 //! let mut block = cf.log.create_block().await?;
 //!
@@ -124,7 +124,7 @@ impl Log {
 
     async fn spawn_data_dispatcher(&self, data_downlink: flume::Receiver<Packet>) {
         let data_channels = self.data_channels.clone();
-        crate::spawn(async move {
+        tokio::spawn(async move {
             while let Ok(packet) = data_downlink.recv_async().await {
                 if packet.get_data().len() > 1 {
                     let block_id = packet.get_data()[0];

--- a/src/subsystems/param.rs
+++ b/src/subsystems/param.rs
@@ -147,7 +147,7 @@ impl Param {
         let values = self.values.clone();
         let toc = self.toc.clone();
 
-        crate::spawn(async move {
+        tokio::spawn(async move {
             while let Ok(pk) = misc_downlink.recv_async().await {
                 if pk.get_data()[0] != 1 {
                     continue;
@@ -216,8 +216,8 @@ impl Param {
     /// # use crazyflie_lib::{Crazyflie, Value, Error};
     /// # use crazyflie_link::LinkContext;
     /// # async fn example() -> Result<(), Error> {
-    /// # let context = LinkContext::new(async_executors::AsyncStd);
-    /// # let cf = Crazyflie::connect_from_uri(async_executors::AsyncStd, &context, "radio://0/60/2M/E7E7E7E7E7").await?;
+    /// # let context = LinkContext::new();
+    /// # let cf = Crazyflie::connect_from_uri(&context, "radio://0/60/2M/E7E7E7E7E7").await?;
     /// cf.param.set("example.param", 42u16).await?;  // From primitive
     /// cf.param.set("example.param", Value::U16(42)).await?;  // From Value
     /// # Ok(())
@@ -274,8 +274,8 @@ impl Param {
     /// # use crazyflie_lib::{Crazyflie, Value, Error};
     /// # use crazyflie_link::LinkContext;
     /// # async fn example() -> Result<(), Error> {
-    /// # let context = LinkContext::new(async_executors::AsyncStd);
-    /// # let cf = Crazyflie::connect_from_uri(async_executors::AsyncStd, &context, "radio://0/60/2M/E7E7E7E7E7").await?;
+    /// # let context = LinkContext::new();
+    /// # let cf = Crazyflie::connect_from_uri(&context, "radio://0/60/2M/E7E7E7E7E7").await?;
     /// let example: u16 = cf.param.get("example.param").await?;  // To primitive
     /// dbg!(example);  // 42
     /// let example: Value = cf.param.get("example.param").await?;  // To Value

--- a/tests/syncsend_test.rs
+++ b/tests/syncsend_test.rs
@@ -1,11 +1,10 @@
 // Test that the Crazyflie object can be sent between threads
 
 use std::thread::spawn;
-use crazyflie_lib::Crazyflie;
 
-#[async_std::test]
+#[tokio::test]
 async fn crazyflie_can_be_sent_to_thread() -> Result<(), Box<dyn std::error::Error>> {
-    let link_context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+    let link_context = crazyflie_link::LinkContext::new();
 
     // Scan for Crazyflies on the default address
     let found = link_context.scan([0xE7; 5]).await?;
@@ -13,7 +12,6 @@ async fn crazyflie_can_be_sent_to_thread() -> Result<(), Box<dyn std::error::Err
     if let Some(uri) = found.first() {
         // Connect to the first Crazyflie found
         let cf = crazyflie_lib::Crazyflie::connect_from_uri(
-            async_executors::AsyncStd,
             &link_context,
             uri,
         )


### PR DESCRIPTION
This PR removes the usage of async_executors and instead moves to a feature based implementation which uses a feature to select the async runtime used by the lib. The only current implementation of this is tokio, so this feature needs to be set otherwise the lib will not compile.

This depends on this crazyflie-link PR to work: https://github.com/bitcraze/crazyflie-link-rs/pull/8