### PR TITLE
Share one TOC download between simultaneously connecting Crazyflies

### DIFF
--- a/src/crtp_utils.rs
+++ b/src/crtp_utils.rs
@@ -10,14 +10,16 @@ use flume as channel;
 use flume::{Receiver, Sender};
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Mutex, MutexGuard, OnceLock, Weak};
 use std::time::Duration;
 use std::{
     convert::{TryFrom, TryInto},
     sync::Arc,
 };
+use tokio::sync::watch;
 
 pub struct CrtpDispatch {
     link: Arc<crazyflie_link::Connection>,
@@ -105,39 +107,99 @@ const TOC_INFO: u8 = 3;
 /// Bump when ParamItemInfo or LogItemInfo serialization changes.
 const TOC_CACHE_VERSION: u8 = 1;
 
-pub(crate) async fn fetch_toc<C, T, E>(
-    port: u8,
-    uplink: channel::Sender<Packet>,
-    downlink: channel::Receiver<Packet>,
-    toc_cache: C,
-) -> Result<std::collections::BTreeMap<String, (u16, T)>>
-where
-    C: TocCache,
-    T: TryFrom<u8, Error = E> + Serialize + for<'de> Deserialize<'de>,
-    E: Into<Error>,
-{
-    let pk = Packet::new(port, 0, vec![TOC_INFO]);
-    uplink
-        .send_async(pk)
-        .await
-        .map_err(|_| Error::Disconnected)?;
+/// A TOC download that is currently in progress.
+///
+/// The connection that created the slot is the "leader": it performs the actual
+/// download and publishes the serialized TOC on `done`. Connections that find an
+/// existing slot for the same key are "followers": they send no packets at all and
+/// simply wait for the leader's result.
+///
+/// The slot removes itself from [`in_flight_map`] when it is dropped, which happens
+/// on success, on error, and on cancellation alike.
+struct TocFetchSlot {
+    key: [u8; 5],
+    done: watch::Sender<Option<String>>,
+}
 
-    let pk = downlink.wait_packet(port, TOC_CHANNEL, &[TOC_INFO]).await?;
+impl Drop for TocFetchSlot {
+    fn drop(&mut self) {
+        let mut map = lock_in_flight();
+        // Only remove a dead entry. A live one belongs to a leader that was elected
+        // after this slot was already on its way out, and must be left alone.
+        if map.get(&self.key).is_some_and(|slot| slot.strong_count() == 0) {
+            map.remove(&self.key);
+        }
+    }
+}
 
-    let toc_len = u16::from_le_bytes(pk.get_data()[1..3].try_into()?);
-    let toc_crc32 = u32::from_le_bytes(pk.get_data()[3..7].try_into()?);
+/// Role of a connection for a TOC download that is not served from the cache.
+enum TocFetch {
+    /// No download was in progress: this connection has to perform it.
+    Lead(Arc<TocFetchSlot>),
+    /// A download is already in progress: wait for its result instead.
+    Follow(watch::Receiver<Option<String>>),
+}
 
-    let mut toc = std::collections::BTreeMap::new();
-    let crc_bytes = toc_crc32.to_le_bytes();
-    let cache_key: [u8; 5] = [TOC_CACHE_VERSION, crc_bytes[0], crc_bytes[1], crc_bytes[2], crc_bytes[3]];
+/// TOC downloads currently in progress, keyed by cache key.
+///
+/// The map holds [`Weak`] references so that a leader which is dropped mid-download
+/// (a failed link, a cancelled connect future) cannot leave a permanently occupied
+/// entry behind. Entries are removed when the slot is dropped, so the map is empty
+/// whenever no TOC download is running.
+fn in_flight_map() -> &'static Mutex<HashMap<[u8; 5], Weak<TocFetchSlot>>> {
+    static IN_FLIGHT: OnceLock<Mutex<HashMap<[u8; 5], Weak<TocFetchSlot>>>> = OnceLock::new();
+    IN_FLIGHT.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
-    // Check cache first
-    if let Some(toc_str) = toc_cache.get_toc(&cache_key) {
-        toc = serde_json::from_str(&toc_str).map_err(|e| Error::InvalidParameter(format!("Failed to deserialize TOC cache: {}", e)))?;
-        return Ok(toc);
+fn lock_in_flight() -> MutexGuard<'static, HashMap<[u8; 5], Weak<TocFetchSlot>>> {
+    // The lock is only ever held for a map lookup, never across an await, so a
+    // poisoned mutex carries no broken invariant and the map stays usable.
+    in_flight_map()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Join the download already in progress for `key`, or become the one that performs it.
+fn join_or_lead(key: [u8; 5]) -> TocFetch {
+    let mut map = lock_in_flight();
+
+    let running = map.get(&key).and_then(Weak::upgrade);
+    if let Some(slot) = running {
+        let receiver = slot.done.subscribe();
+        // Release the lock before `slot` goes out of scope: dropping the last
+        // reference runs `TocFetchSlot::drop`, which takes the same lock.
+        drop(map);
+        return TocFetch::Follow(receiver);
     }
 
-    // Fetch TOC from device
+    let (done, _) = watch::channel(None);
+    let slot = Arc::new(TocFetchSlot { key, done });
+    map.insert(key, Arc::downgrade(&slot));
+    TocFetch::Lead(slot)
+}
+
+fn deserialize_toc<T>(toc_str: &str) -> Result<BTreeMap<String, (u16, T)>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    serde_json::from_str(toc_str).map_err(|e| {
+        Error::InvalidParameter(format!("Failed to deserialize TOC cache: {}", e))
+    })
+}
+
+/// Download the full TOC from the Crazyflie, one item at a time.
+async fn download_toc<T, E>(
+    port: u8,
+    uplink: &channel::Sender<Packet>,
+    downlink: &channel::Receiver<Packet>,
+    toc_len: u16,
+) -> Result<BTreeMap<String, (u16, T)>>
+where
+    T: TryFrom<u8, Error = E>,
+    E: Into<Error>,
+{
+    let mut toc = BTreeMap::new();
+
     for i in 0..toc_len {
         let pk = Packet::new(
             port,
@@ -160,11 +222,68 @@ where
         toc.insert(format!("{}.{}", group, name), (id, item_type));
     }
 
-    // Store in cache
-    let toc_str = serde_json::to_string(&toc).map_err(|e| Error::InvalidParameter(format!("Failed to serialize TOC: {}", e)))?;
-    toc_cache.store_toc(&cache_key, &toc_str);
-
     Ok(toc)
+}
+
+pub(crate) async fn fetch_toc<C, T, E>(
+    port: u8,
+    uplink: channel::Sender<Packet>,
+    downlink: channel::Receiver<Packet>,
+    toc_cache: C,
+) -> Result<std::collections::BTreeMap<String, (u16, T)>>
+where
+    C: TocCache,
+    T: TryFrom<u8, Error = E> + Serialize + for<'de> Deserialize<'de>,
+    E: Into<Error>,
+{
+    let pk = Packet::new(port, 0, vec![TOC_INFO]);
+    uplink
+        .send_async(pk)
+        .await
+        .map_err(|_| Error::Disconnected)?;
+
+    let pk = downlink.wait_packet(port, TOC_CHANNEL, &[TOC_INFO]).await?;
+
+    let toc_len = u16::from_le_bytes(pk.get_data()[1..3].try_into()?);
+    let toc_crc32 = u32::from_le_bytes(pk.get_data()[3..7].try_into()?);
+
+    let crc_bytes = toc_crc32.to_le_bytes();
+    let cache_key: [u8; 5] = [TOC_CACHE_VERSION, crc_bytes[0], crc_bytes[1], crc_bytes[2], crc_bytes[3]];
+
+    // Check cache first
+    if let Some(toc_str) = toc_cache.get_toc(&cache_key) {
+        return deserialize_toc(&toc_str);
+    }
+
+    // Cache miss. Crazyflies running the same firmware share a cache key, so a swarm
+    // connecting at once would otherwise download the same TOC once per Crazyflie,
+    // all of them competing for the same radio bandwidth. Download it once and share
+    // the result instead.
+    match join_or_lead(cache_key) {
+        TocFetch::Lead(slot) => {
+            let toc = download_toc::<T, E>(port, &uplink, &downlink, toc_len).await?;
+
+            let toc_str = serde_json::to_string(&toc).map_err(|e| {
+                Error::InvalidParameter(format!("Failed to serialize TOC: {}", e))
+            })?;
+            toc_cache.store_toc(&cache_key, &toc_str);
+
+            // Hand the result to everyone waiting on this download. Dropping `slot`
+            // without sending, on the error paths above, closes the channel and lets
+            // the followers fall back to downloading the TOC themselves.
+            let _ = slot.done.send(Some(toc_str));
+
+            Ok(toc)
+        }
+        TocFetch::Follow(mut done) => match done.wait_for(Option::is_some).await {
+            Ok(toc_str) => {
+                deserialize_toc(toc_str.as_deref().expect("waited for a published TOC"))
+            }
+            // The leader failed or was cancelled before publishing anything. Nothing
+            // is known about why, so just download the TOC over this connection.
+            Err(_) => download_toc(port, &uplink, &downlink, toc_len).await,
+        },
+    }
 }
 
 pub fn crtp_channel_dispatcher(
@@ -274,4 +393,78 @@ pub trait TocCache: Clone + Send + Sync + 'static
     /// * `key` - An opaque byte key used to identify the TOC.
     /// * `toc` - The TOC string to be stored.
     fn store_toc(&self, key: &[u8], toc: &str);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The in-flight map is process-wide, so every test uses its own key to stay
+    /// independent of the others.
+    fn key(id: u8) -> [u8; 5] {
+        [TOC_CACHE_VERSION, id, 0, 0, 0]
+    }
+
+    #[test]
+    fn first_caller_leads_and_the_next_one_follows() {
+        let key = key(1);
+
+        let leader = match join_or_lead(key) {
+            TocFetch::Lead(slot) => slot,
+            TocFetch::Follow(_) => panic!("nothing was in flight, should have become leader"),
+        };
+        assert!(matches!(join_or_lead(key), TocFetch::Follow(_)));
+
+        drop(leader);
+    }
+
+    #[test]
+    fn dropping_the_leader_frees_the_key() {
+        let key = key(2);
+
+        let leader = join_or_lead(key);
+        assert!(matches!(leader, TocFetch::Lead(_)));
+        drop(leader);
+
+        assert!(lock_in_flight().get(&key).is_none());
+        // A cancelled or failed download must not block later attempts.
+        assert!(matches!(join_or_lead(key), TocFetch::Lead(_)));
+    }
+
+    #[tokio::test]
+    async fn followers_get_the_toc_downloaded_by_the_leader() {
+        let key = key(3);
+
+        let TocFetch::Lead(leader) = join_or_lead(key) else {
+            panic!("nothing was in flight, should have become leader");
+        };
+        let TocFetch::Follow(mut follower) = join_or_lead(key) else {
+            panic!("a download is in flight, should have become follower");
+        };
+
+        let toc = r#"{"example.value":[1,1]}"#;
+        let _ = leader.done.send(Some(toc.to_string()));
+        drop(leader);
+
+        let received = follower.wait_for(Option::is_some).await;
+        assert_eq!(received.unwrap().as_deref(), Some(toc));
+    }
+
+    #[tokio::test]
+    async fn followers_are_released_when_the_leader_disappears() {
+        let key = key(4);
+
+        let TocFetch::Lead(leader) = join_or_lead(key) else {
+            panic!("nothing was in flight, should have become leader");
+        };
+        let TocFetch::Follow(mut follower) = join_or_lead(key) else {
+            panic!("a download is in flight, should have become follower");
+        };
+
+        // The leader's link died, or its connect future was cancelled.
+        drop(leader);
+
+        // The follower must not wait forever: it falls back to its own download.
+        assert!(follower.wait_for(Option::is_some).await.is_err());
+    }
 }


### PR DESCRIPTION
Suggestion to share one TOC download between simultaneously connecting Crazyflies.
We still have to share bandwidth with all connected Crazyflies, even if they are "idle" they will keep connection alive, so I have to investigate if this gives any (significant) benefit.